### PR TITLE
GraniteMoeHybrid Support Shared Experts Only

### DIFF
--- a/src/transformers/models/granitemoehybrid/convert_checkpoints.py
+++ b/src/transformers/models/granitemoehybrid/convert_checkpoints.py
@@ -195,7 +195,7 @@ def main(
                 config.hidden_size //
                 config.num_attention_heads
             )
-            config.partial_rotary_config = (
+            config.partial_rotary_factor = (
                 config.attn_rotary_emb // head_dim
             )
             try:

--- a/src/transformers/models/granitemoehybrid/convert_checkpoints.py
+++ b/src/transformers/models/granitemoehybrid/convert_checkpoints.py
@@ -1,0 +1,144 @@
+import torch
+from typing import Dict
+from collections import defaultdict
+
+# dependency on accelerate
+from accelerate import init_on_device
+from transformers.modeling_utils import no_init_weights
+
+from transformers import (
+    AutoModelForCausalLM,
+    GraniteMoeHybridForCausalLM,
+    GraniteMoeHybridConfig,
+    BambaForCausalLM,
+)
+
+def convert_bamba_state_dict(
+    state_dict: Dict,
+):
+    table = {
+        'input_layernorm.weight': None,
+        'pre_ff_layernorm.weight': 'post_attention_layernorm.weight',
+        'embed_tokens.weight': None,
+        'mamba.conv1d.weight': None,
+        'mamba.conv1d.bias': None,
+        'mamba.in_proj.weight': None,
+        'mamba.out_proj.weight': None,
+        'mamba.A_log': None,
+        'mamba.D': None,
+        'mamba.dt_bias': None,
+        'self_attn.q_proj.weight': None,
+        'self_attn.k_proj.weight': None,
+        'self_attn.v_proj.weight': None,
+        'self_attn.o_proj.weight': None,
+        'feed_forward.down_proj.weight': 'shared_mlp.output_linear.weight',
+        (
+            'feed_forward.gate_proj.weight',
+            'feed_forward.up_proj.weight'
+        ): 'shared_mlp.input_linear.weight',
+        'mamba.norm.weight': None,
+        'final_layernorm.weight': 'norm.weight',
+        'lm_head.weight': None,
+    }
+
+    fused = defaultdict(dict)
+
+    # sort in decreasing number of levels.
+    # - more levels higher priority
+    table_keys = sorted(
+        table.keys(), key=lambda x: -x.count('.')
+    )
+
+    converted_sd: Dict = {}
+
+    for key, tensor in state_dict.items():
+        new_key = None
+
+        pattern = None
+        is_fused = False
+        for ks in table_keys:
+
+            # fused case
+            if isinstance(ks, str):
+                is_fused = False
+                ks = (ks,)
+            else:
+                is_fused = True
+
+            found = False
+            for k in ks:
+                if key.endswith(k):
+                    pattern = k
+                    found = True
+                    break
+            if found:
+                break
+
+        if (
+            (is_fused and (ks in table))
+            or (pattern in table)
+        ):
+            if is_fused or table[pattern]:
+                new_key = key.replace(
+                    pattern, (
+                        table[pattern] if not is_fused else 
+                        table[ks]
+                    )
+                )
+            else:
+                new_key = key
+        
+        if new_key:
+            if not is_fused:
+                converted_sd[new_key] = tensor
+            else:
+                fused[new_key][pattern] = tensor
+
+                if len(fused[new_key]) == len(ks):
+                    converted_sd[new_key] = torch.concat(
+                        [fused[new_key][k] for k in ks]
+                    )
+
+    return converted_sd
+
+def convert_bamba_checkpoint(
+    checkpoint_dir: str,
+    output_dir: str = None,
+):
+
+    # load the bamba checkpoint
+    ref = BambaForCausalLM.from_pretrained(checkpoint_dir)
+
+    with init_on_device('cpu'), no_init_weights():
+        head_dim = ref.config.hidden_size // ref.config.num_attention_heads
+        config = GraniteMoeHybridConfig(
+            **{
+                **{
+                    k:v for k,v in ref.config.to_dict().items()
+                    if k not in [
+                        'z_loss_coefficient',
+                        'attn_layer_indices',
+                    ]
+                },
+                'architectures': ['GraniteMoeHybridForCausalLM'],
+                'num_local_experts': 0,
+                'shared_intermediate_size': ref.config.intermediate_size,
+                'layer_types': [
+                    'attention' if i in ref.config.attn_layer_indices else 'mamba' 
+                    for i in range(ref.config.num_hidden_layers)
+                ],
+                'attention_multiplier': head_dim**-0.5,
+            },
+        )
+        # only automodel has a from_config function
+        model = AutoModelForCausalLM.from_config(config)
+
+    sd = convert_bamba_state_dict(ref.state_dict())
+    model.load_state_dict(sd)
+
+    # save the new checkpoint
+    if output_dir is None:
+        return model
+
+    model.save_pretrained(output_dir)
+

--- a/src/transformers/models/granitemoehybrid/convert_checkpoints.py
+++ b/src/transformers/models/granitemoehybrid/convert_checkpoints.py
@@ -8,12 +8,14 @@ from transformers.modeling_utils import no_init_weights
 
 from transformers import (
     AutoModelForCausalLM,
-    GraniteMoeHybridForCausalLM,
     GraniteMoeHybridConfig,
     BambaForCausalLM,
+    BambaConfig,
 )
 
-def convert_bamba_state_dict(
+import os, json
+
+def convert_state_dict(
     state_dict: Dict,
 ):
     table = {
@@ -101,44 +103,134 @@ def convert_bamba_state_dict(
 
     return converted_sd
 
-def convert_bamba_checkpoint(
-    checkpoint_dir: str,
-    output_dir: str = None,
+def convert_to_granite_model(
+    config: BambaConfig,
+    state_dict: Dict,
 ):
-
-    # load the bamba checkpoint
-    ref = BambaForCausalLM.from_pretrained(checkpoint_dir)
+    # only supports these now
+    position_emb_type = {
+        0.: None,
+        1.: 'rope'
+    }
 
     with init_on_device('cpu'), no_init_weights():
-        head_dim = ref.config.hidden_size // ref.config.num_attention_heads
+        head_dim = config.hidden_size // config.num_attention_heads
         config = GraniteMoeHybridConfig(
             **{
                 **{
-                    k:v for k,v in ref.config.to_dict().items()
+                    k:v for k,v in config.to_dict().items()
                     if k not in [
                         'z_loss_coefficient',
                         'attn_layer_indices',
+                        'partial_rotary_factor'
                     ]
                 },
                 'architectures': ['GraniteMoeHybridForCausalLM'],
                 'num_local_experts': 0,
-                'shared_intermediate_size': ref.config.intermediate_size,
+                'shared_intermediate_size': config.intermediate_size,
                 'layer_types': [
-                    'attention' if i in ref.config.attn_layer_indices else 'mamba' 
-                    for i in range(ref.config.num_hidden_layers)
+                    'attention' if i in config.attn_layer_indices else 'mamba' 
+                    for i in range(config.num_hidden_layers)
                 ],
                 'attention_multiplier': head_dim**-0.5,
+                'position_embedding_type': position_emb_type[
+                    config.partial_rotary_factor
+                ]
             },
         )
         # only automodel has a from_config function
         model = AutoModelForCausalLM.from_config(config)
 
-    sd = convert_bamba_state_dict(ref.state_dict())
+    sd = convert_state_dict(state_dict)
     model.load_state_dict(sd)
 
     # save the new checkpoint
-    if output_dir is None:
-        return model
+    return model
 
-    model.save_pretrained(output_dir)
+def main(
+    convert_from_dir: str,
+    output_to_dir: str,
+    dtype: str = 'fp16',
+    strategy: str = 'mamba_ssm',
+):
+    DTYPES = {
+        'fp16': torch.float16,
+        'fp32': torch.float32,
+        'bf16': torch.bfloat16,
+    }
+    assert dtype in DTYPES
+    assert strategy in {'mamba_ssm', 'bamba'}
+
+    # get a bamba checkpoint first
+    if strategy == 'mamba_ssm':
+        from transformers.models.bamba.convert_mamba_ssm_checkpoint import (
+            convert_ssm_config_to_hf_config,
+            convert_state_dict_from_mamba_ssm
+        )
+
+        # FIXME: Not handled
+        token_ids = {}
+        # some code replication
+
+        unsettables = {
+            "mamba_d_head": 64,
+            "mamba_d_state": 128,
+            "mamba_n_groups": 1,
+            "rms_norm_eps": 1e-5,
+        }
+
+        config_path = os.path.join(convert_from_dir, "config.json")
+        with open(config_path, "r", encoding="utf-8") as json_file:
+            config_data = json.load(json_file)
+
+        # have the fix here
+        if 'attn_rotary_emb' in config_data:
+            head_dim = (
+                config_data['hidden_size'] //
+                config_data['num_attention_heads']
+            )
+            config_data['partial_rotary_config'] = (
+                config_data['attn_rotary_emb'] //
+                head_dim
+            )
+            del config_data['attn_rotary_emb']
+
+        config = convert_ssm_config_to_hf_config(
+            config_ssm=config_data,
+            **token_ids,
+            **unsettables,
+        )
+
+        # Load state dict of the original model and transfer to hf model
+        state_dict = torch.load(
+            os.path.join(convert_from_dir, "pytorch_model.bin"),
+            map_location="cpu",
+            weights_only=True,
+        )
+
+        state_dict = convert_state_dict_from_mamba_ssm(state_dict)
+        
+    else:
+        ref = BambaForCausalLM.from_pretrained(convert_from_dir)
+        config = ref.config
+        state_dict = ref.state_dict()
+
+    # convert
+    print ('converting to granite')
+    model = convert_to_granite_model(
+        config, state_dict,
+    )
+
+    # change dtype
+    print ('change dtype to', dtype)
+    model = model.to(DTYPES[dtype])
+
+    # save
+    print ('save model to', output_to_dir)
+    model.save_pretrained(output_to_dir)
+
+if __name__ == '__main__':
+
+    import fire
+    fire.Fire(main)
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

This PR
- allows `GraniteMoeHybridForCausalLM` (and maybe also `GraniteMoeSharedForCausalLM`) to not have any local experts (i.e., only shared experts)
- one use case is to allow `bamba` models to run as a special case of `GraniteMoeHybridForCausalLM`.

Questions:
- can we have the conversion script to demonstrate how to convert bamba models.
- if we disable the local experts, can we just return `None` for `router_logits`? Or we should force the config (in the conversion) to set `output_router_logits=False`?
- should we also allow `GraniteMoeHybridForCausalLM` to support `padding-free` like bamba

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
